### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,6 @@
     "morgan": "~1.7.0",
     "mousetrap": "~1.6.0",
     "namespace-constants": "~0.1.1",
-    "node-uuid": "~1.4.7",
     "normalize.css": "~5.0.0",
     "package-json": "~2.4.0",
     "pubsub-js": "~1.5.4",
@@ -196,6 +195,7 @@
     "stacktrace-js": "~1.3.1",
     "superagent": "~2.3.0",
     "three": "~0.82.1",
+    "uuid": "^3.0.0",
     "webappengine": "~1.1.3",
     "winston": "~2.3.0"
   },

--- a/src/app/api/api.macros.js
+++ b/src/app/api/api.macros.js
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import _ from 'lodash';
-import uuid from 'node-uuid';
+import uuid from 'uuid';
 import settings from '../config/settings';
 import log from '../lib/log';
 

--- a/src/app/api/api.users.js
+++ b/src/app/api/api.users.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import jwt from 'jsonwebtoken';
 import bcrypt from 'bcrypt-nodejs';
 import _ from 'lodash';
-import uuid from 'node-uuid';
+import uuid from 'uuid';
 import settings from '../config/settings';
 import {
     ERR_BAD_REQUEST,


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.